### PR TITLE
Updated footer.html

### DIFF
--- a/themes/glimpse/layouts/partials/footer.html
+++ b/themes/glimpse/layouts/partials/footer.html
@@ -8,9 +8,9 @@
         >
       </div>
       <div class="col text-right">
-        <a href="/privacy/" class="mr-3">Privacy Policy</a>
-        <a href="/code-of-conduct/" class="mr-3">Code of Conduct</a>
-        <a href="https://github.com/glimpse-editor/Glimpse" target="_blank"
+        <a href="/privacy/" class="figure">Privacy Policy</a>
+        <a href="/code-of-conduct/" class="ml-3 figure">Code of Conduct</a>
+        <a href="https://github.com/glimpse-editor/Glimpse" class="ml-3 figure" target="_blank"
           >Source Code</a
         >
       </div>


### PR DESCRIPTION
Changing classes to fix alignment for footer links on mobile and smaller screens.

before: 
![before](https://user-images.githubusercontent.com/972280/88083952-ab014c80-cb51-11ea-9805-adae2133d2e4.png)

after:
![after](https://user-images.githubusercontent.com/972280/88083970-afc60080-cb51-11ea-99e9-1d2420485556.png)

There's no change to the display on larger screens